### PR TITLE
feat: added mechanism for sprite switching within radius

### DIFF
--- a/Assets/Dialogues/Test1.asset
+++ b/Assets/Dialogues/Test1.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4640a375081474b7a9f9936854cdcb8e, type: 3}
+  m_Name: Test1
+  m_EditorClassIdentifier: 
+  sentences:
+  - Test
+  - Mic Check
+  - Hello?

--- a/Assets/Dialogues/Test1.asset.meta
+++ b/Assets/Dialogues/Test1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e6a32d20f8f34caeaf39ff9a3aa4479
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/NPC.prefab
+++ b/Assets/Prefabs/NPC.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 202458364147761632}
   - component: {fileID: 202458364147761633}
   - component: {fileID: 202458364147761635}
+  - component: {fileID: -8940716008333212642}
   m_Layer: 8
   m_Name: NPC
   m_TagString: Interactable
@@ -96,10 +97,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18353866fb16b49cb8a141f8af8a44df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  radius: 3
-  dialogue:
-    name: 
-    sentences: []
+  interactableSprites:
+    Highlighted: {fileID: 0}
+    Original: {fileID: 0}
+  name: 
+  dialogue: {fileID: 0}
+--- !u!58 &-8940716008333212642
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 202458364147761638}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.08
 --- !u!1 &202458364235490210
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/NPCTestLevel.unity
+++ b/Assets/Scenes/NPCTestLevel.unity
@@ -494,6 +494,7 @@ GameObject:
   - component: {fileID: 425937101}
   - component: {fileID: 425937100}
   - component: {fileID: 425937102}
+  - component: {fileID: 425937103}
   m_Layer: 8
   m_Name: NPC
   m_TagString: Interactable
@@ -579,9 +580,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18353866fb16b49cb8a141f8af8a44df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  radius: 3
+  interactableSprites:
+    Highlighted: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+    Original: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
   name: Kidney
   dialogue: {fileID: 11400000, guid: 943954cbab2d5954b933931cea7f29b4, type: 2}
+--- !u!58 &425937103
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425937099}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.08
 --- !u!1 &464878536
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/NPCTestLevel.unity
+++ b/Assets/Scenes/NPCTestLevel.unity
@@ -215,13 +215,86 @@ RectTransform:
   m_Children:
   - {fileID: 464878537}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &177472027
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.66
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.3099427
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761635, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: interactableSprites.Highlighted
+      value: 
+      objectReference: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+    - target: {fileID: 202458364147761635, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: interactableSprites.Original
+      value: 
+      objectReference: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+    - target: {fileID: 202458364147761635, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: dialogue
+      value: 
+      objectReference: {fileID: 11400000, guid: 0e6a32d20f8f34caeaf39ff9a3aa4479, type: 2}
+    - target: {fileID: 202458364147761635, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: name
+      value: Kidney Bean
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761638, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_Name
+      value: NPC1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
 --- !u!1 &206468020
 GameObject:
   m_ObjectHideFlags: 0
@@ -366,7 +439,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 231419522}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -1.28, y: -0.61, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1466102182}
@@ -483,124 +556,6 @@ MonoBehaviour:
   InteractablesLayer:
     serializedVersion: 2
     m_Bits: 256
---- !u!1 &425937099
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 425937101}
-  - component: {fileID: 425937100}
-  - component: {fileID: 425937102}
-  - component: {fileID: 425937103}
-  m_Layer: 8
-  m_Name: NPC
-  m_TagString: Interactable
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &425937100
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 425937099}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.16, y: 0.16}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &425937101
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 425937099}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.273442, y: -0.2977602, z: -6.3099427}
-  m_LocalScale: {x: 5, y: 5, z: 5}
-  m_Children:
-  - {fileID: 1550088483}
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &425937102
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 425937099}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 18353866fb16b49cb8a141f8af8a44df, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  interactableSprites:
-    Highlighted: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-    Original: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
-  name: Kidney
-  dialogue: {fileID: 11400000, guid: 943954cbab2d5954b933931cea7f29b4, type: 2}
---- !u!58 &425937103
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 425937099}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.08
 --- !u!1 &464878536
 GameObject:
   m_ObjectHideFlags: 0
@@ -1916,6 +1871,79 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1001 &924217159
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.3099427
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761632, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761635, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: interactableSprites.Highlighted
+      value: 
+      objectReference: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+    - target: {fileID: 202458364147761635, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: interactableSprites.Original
+      value: 
+      objectReference: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+    - target: {fileID: 202458364147761635, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: dialogue
+      value: 
+      objectReference: {fileID: 11400000, guid: e34c3660232014e4ebfe386463f27101, type: 2}
+    - target: {fileID: 202458364147761635, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: name
+      value: Lima Bean
+      objectReference: {fileID: 0}
+    - target: {fileID: 202458364147761638, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
+      propertyPath: m_Name
+      value: NPC2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d98ec6e53c13e47859770d68f05d95ed, type: 3}
 --- !u!1 &999760637
 GameObject:
   m_ObjectHideFlags: 0
@@ -1980,7 +2008,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1387908721
 GameObject:
@@ -2024,7 +2052,7 @@ Transform:
   m_Children:
   - {fileID: 840731749}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1401394595
 GameObject:
@@ -2070,7 +2098,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1427776520
 GameObject:
@@ -2180,37 +2208,6 @@ Transform:
   m_Children:
   - {fileID: 676217724}
   m_Father: {fileID: 231419525}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1550088482
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1550088483}
-  m_Layer: 8
-  m_Name: COLLIDERS
-  m_TagString: Interactable
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1550088483
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1550088482}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1738992272}
-  m_Father: {fileID: 425937101}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1580846901
@@ -2424,63 +2421,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1683161389}
   m_CullTransparentMesh: 0
---- !u!1 &1738992271
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1738992272}
-  - component: {fileID: 1738992273}
-  m_Layer: 8
-  m_Name: Body
-  m_TagString: Interactable
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1738992272
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1738992271}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1550088483}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &1738992273
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1738992271}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.17, y: 0.17}
-  m_EdgeRadius: 0
 --- !u!1 &1988632009
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Interactable/Dialogue/Dialogue.cs
+++ b/Assets/Scripts/Interactable/Dialogue/Dialogue.cs
@@ -2,6 +2,7 @@
 
 [CreateAssetMenu(fileName = "New Dialogue", menuName = "NPC/Dialogue")]
 public class Dialogue : ScriptableObject {
+	// TODO: USING THE SCRIPTABLE OBJECT IS DOING WEIRD STUFF (LOOKS LIKE REUSING THE SAME DIALOG OBJECT AND IN SOME CASES IS NULL)
 	[TextArea(3, 10)]
 	public string[] sentences;
 }

--- a/Assets/Scripts/Interactable/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Interactable/Dialogue/DialogueManager.cs
@@ -27,9 +27,13 @@ public class DialogueManager : MonoBehaviour {
 		sentences = new Queue<string>();
 	}
 
-	public void StartDialogue(Dialogue dialogue) {
+	public void StartDialogue(string name, Dialogue dialogue) {
+		if (name == "") {
+			EndDialogue();
+			return;
+		}
 		animator.SetBool("IsOpen", true);
-		nameText.text = dialogue.name;
+		nameText.text = name;
 
 		sentences.Clear();
 

--- a/Assets/Scripts/Interactable/Interactable.cs
+++ b/Assets/Scripts/Interactable/Interactable.cs
@@ -1,9 +1,44 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
+[RequireComponent(typeof(SpriteRenderer))]
+[RequireComponent(typeof(CircleCollider2D))]
 public class Interactable : MonoBehaviour {
-	public float radius = 3f;
+
+	[SerializeField]
+	private InteractableSprites interactableSprites = new InteractableSprites();
+
+	SpriteRenderer spriteRenderer;
+
+	private CircleCollider2D viewableScope;
+
+	private float scopeRadius = .2f;
+
+	private bool highlighted = false;
+
+	void Start() {
+		viewableScope = GetComponent<CircleCollider2D>();
+		viewableScope.radius = scopeRadius;
+		viewableScope.isTrigger = true;
+		spriteRenderer = GetComponent<SpriteRenderer>();
+		spriteRenderer.sprite = interactableSprites.Original;
+	}
 
 	public virtual void Interact() {
 		Debug.Log("Interaction not implemented");
+	}
+
+	public void Highlight() {
+		if (interactableSprites.Highlighted != null) {
+			spriteRenderer.sprite = interactableSprites.Highlighted;
+			highlighted = true;
+		}
+	}
+
+	public void Unhighlight() {
+		if (highlighted) {
+			spriteRenderer.sprite = interactableSprites.Original;
+			highlighted = false;
+		}
 	}
 }

--- a/Assets/Scripts/Interactable/InteractableSprites.cs
+++ b/Assets/Scripts/Interactable/InteractableSprites.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class InteractableSprites {
+	public Sprite Highlighted;
+	public Sprite Original;
+}

--- a/Assets/Scripts/Interactable/InteractableSprites.cs.meta
+++ b/Assets/Scripts/Interactable/InteractableSprites.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 066fbe3528eb8491b8105e0e3cf54f00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactable/NPC.cs
+++ b/Assets/Scripts/Interactable/NPC.cs
@@ -1,5 +1,4 @@
 using Moonshot.GameManagement;
-using UnityEngine;
 
 public class NPC : Interactable {
 

--- a/Assets/Scripts/Interactable/NPC.cs
+++ b/Assets/Scripts/Interactable/NPC.cs
@@ -18,7 +18,7 @@ public class NPC : Interactable {
 				- init quest dialog
 			- 
 		*/
-		if (dialogue != null && name != null && name != "") {
+		if (dialogue != null && name != null) {
 			DialogueManager.Instance.StartDialogue(name, dialogue);
 			GameEvents.Instance.DialogueStarted();
 		}

--- a/Assets/Scripts/Interactable/NPC.cs
+++ b/Assets/Scripts/Interactable/NPC.cs
@@ -1,4 +1,5 @@
 using Moonshot.GameManagement;
+using UnityEngine;
 
 public class NPC : Interactable {
 
@@ -17,8 +18,10 @@ public class NPC : Interactable {
 				- init quest dialog
 			- 
 		*/
-		DialogueManager.Instance.StartDialogue(dialogue);
-		GameEvents.Instance.DialogueStarted();
+		if (dialogue != null && name != null && name != "") {
+			DialogueManager.Instance.StartDialogue(name, dialogue);
+			GameEvents.Instance.DialogueStarted();
+		}
 		// Respond();
 	}
 

--- a/Assets/Scripts/Player/Interact.cs
+++ b/Assets/Scripts/Player/Interact.cs
@@ -7,7 +7,11 @@ namespace Moonshot.Player {
 		[SerializeField]
 		[Range(0f, 10f)]
 		private float radius = 3f;
+
 		[SerializeField] private LayerMask InteractablesLayer;
+
+		private bool hasCollided = false;
+		private string prompt = "Press F";
 
 		void Start() {
 			input = GetComponent<BaseInput>();
@@ -16,6 +20,12 @@ namespace Moonshot.Player {
 		void Update() {
 			if (input.Interact) {
 				CheckHit();
+			}
+		}
+
+		void OnGUI() {
+			if (hasCollided == true) {
+				GUI.Box(new Rect(140, Screen.height - 50, Screen.width - 300, 120), prompt);
 			}
 		}
 
@@ -38,6 +48,7 @@ namespace Moonshot.Player {
 		void OnTriggerEnter2D(Collider2D other) {
 			Interactable interactable = other.GetComponentInParent<Interactable>();
 			if (interactable) {
+				hasCollided = true;
 				interactable.Highlight();
 			}
 		}
@@ -45,6 +56,7 @@ namespace Moonshot.Player {
 		void OnTriggerExit2D(Collider2D other) {
 			Interactable interactable = other.GetComponentInParent<Interactable>();
 			if (interactable) {
+				hasCollided = false;
 				interactable.Unhighlight();
 			}
 		}

--- a/Assets/Scripts/Player/Interact.cs
+++ b/Assets/Scripts/Player/Interact.cs
@@ -30,9 +30,22 @@ namespace Moonshot.Player {
 		void HandleInteractions(Collider2D[] interactables) {
 			// TODO: will need to sort out which interactable to choose
 			Interactable interactable = interactables[0].GetComponentInParent<Interactable>();
-			Debug.Log("hit: " + interactable.name);
 			if (interactable) {
 				interactable.Interact();
+			}
+		}
+
+		void OnTriggerEnter2D(Collider2D other) {
+			Interactable interactable = other.GetComponentInParent<Interactable>();
+			if (interactable) {
+				interactable.Highlight();
+			}
+		}
+
+		void OnTriggerExit2D(Collider2D other) {
+			Interactable interactable = other.GetComponentInParent<Interactable>();
+			if (interactable) {
+				interactable.Unhighlight();
 			}
 		}
 	}


### PR DESCRIPTION
With this setup we shouldn't set the sprite on the sprite renderer for interactables since I do it programmatically in the `Start()` method. This is because the Original attribute in the InteractableSprites class should be used.
![interactable-sprite-switch](https://user-images.githubusercontent.com/11526734/99079240-47c67a80-2585-11eb-9dae-52456ea233f9.gif)
![interactable-prompt](https://user-images.githubusercontent.com/11526734/99159393-720d5a80-26a1-11eb-82fc-f19af2685646.gif)
